### PR TITLE
Fix getting previously created zone-based CKShare

### DIFF
--- a/Sources/MYCloudKit/MYSyncEngine/MYCloudEngine+Share.swift
+++ b/Sources/MYCloudKit/MYSyncEngine/MYCloudEngine+Share.swift
@@ -119,6 +119,6 @@ private extension CKDatabase {
         if let existingShareID = ckRecord.share?.recordID {
             return existingShareID
         }
-        return try? await record(for: ckRecord.recordID).share?.recordID
+        return try? await record(for: .init(recordName: CKRecordNameZoneWideShare, zoneID: ckRecord.recordID.zoneID)).recordID
     }
 }

--- a/Sources/MYCloudKit/MYSyncEngine/MYCloudEngine+Share.swift
+++ b/Sources/MYCloudKit/MYSyncEngine/MYCloudEngine+Share.swift
@@ -49,7 +49,7 @@ extension MYSyncEngine {
         var shareRecord: CKShare
 
         // Reuse existing share if one already exists
-        if let existingShareID = ckRecord.share?.recordID,
+        if let existingShareID = await database.getShareRecordId(ckRecord: ckRecord),
            let existingShare = try? await database.record(for: existingShareID) as? CKShare {
             shareRecord = existingShare
         } else if ckRecord.recordID.recordName == ckRecord.recordID.zoneID.zoneName {
@@ -83,7 +83,7 @@ extension MYSyncEngine {
 
         throw NSError(domain: "MYSync", code: 404, userInfo: [NSLocalizedDescriptionKey: "Failed to save or locate CKShare"])
     }
-
+    
     /// Accepts a shared CloudKit record and fetches updated shared data.
     ///
     /// - Parameter metadata: The `CKShare.Metadata` received via the SceneDelegate.
@@ -111,5 +111,14 @@ extension MYSyncEngine {
 
         // Refresh local shared records
         try await fetch(in: .shared)
+    }
+}
+
+private extension CKDatabase {
+    func getShareRecordId(ckRecord: CKRecord) async -> CKRecord.ID? {
+        if let existingShareID = ckRecord.share?.recordID {
+            return existingShareID
+        }
+        return try? await record(for: ckRecord.recordID).share?.recordID
     }
 }


### PR DESCRIPTION
See original issue #4

This PR updates the public `MYSyncEngine.createShare` method to fetch a previously created `CKShare` via the zone based sharing:

> GIVEN the `createShare` method was called previously
AND the `CKShare` was created via the `CKRecordZone` sharing
WHEN afterwards calling the `createShare` method
THEN the previously created `CKShare` can not be found

My solution was to not only check the `ckRecord.share` variable, but additionally fetch the record by the constant recordName [`CKRecordNameZoneWideShare`](https://developer.apple.com/documentation/cloudkit/ckrecordnamezonewideshare) for a shared-zone-record. Since this fetches the record, as far as I know, this only returns a `CKShare` with internet connection.
```swift
try? await record(for: .init(recordName: CKRecordNameZoneWideShare, zoneID: ckRecord.recordID.zoneID))
```

Additional infos:
- I did not test if this negatively affects the case when a `CKShare` was created using the parent-hierarchy. I would assume since no zone-wide-sharing-zone was created for the given `ckRecord.recordID.zoneID` it would return `nil`.
- Possibly my solution is a workaround and the real solution would be to correctly cache the shared `ckRecord`, which holds a `ckRecord.share` property, since at the moment that variable is always `nil` when recreating the ckRecord from the cache
- Or should the [CKSystemSharingUIObserver](https://developer.apple.com/documentation/cloudkit/cksystemsharinguiobserver) or [UICloudSharingControllerDelegate](https://developer.apple.com/documentation/uikit/uicloudsharingcontrollerdelegate) be used from outside the MyCloudKit library to cache the CKShare record when it changes. If yes, would the MyCloudKit library be able to cache it correctly, since it does not directly conform to the `MYRecordConvertible` protocol